### PR TITLE
Fix asset paths for GitHub Pages

### DIFF
--- a/TAF.html
+++ b/TAF.html
@@ -15,27 +15,27 @@
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,700i,800,800i" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Raleway:400,700,900" rel="stylesheet">
     <!-- Bootstrap core CSS -->
-    <link href="assets/vendors/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
 	<!--<link href="assets/vendors/owl-carousel/owl.carousel.css" rel="stylesheet">-->
-	<link href="assets/vendors/fancybox/jquery.fancybox.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" rel="stylesheet">
 	
 	<!--fontawesome core css-->
-	<link href="assets/vendors/fontawesome/css/font-awesome.min.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 	
 	<!-- Animate CSS -->
-	<link href="assets/vendors/animate/animate.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.2/animate.min.css" rel="stylesheet">
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-    <link href="assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
+    <link href="ie10-viewport-bug-workaround.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="assets/css/style.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
 	
 	 <!-- Owl Carousel -->
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.carousel.min.css">
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.theme.default.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.theme.default.min.css">
 	
-	 <link href="assets/vendors/responsivetabs/responsivetabs.css" rel="stylesheet">
+	 <link href="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/easy-responsive-tabs.min.css" rel="stylesheet">
 	 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
 	 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-685Z66HVS9"></script>
@@ -429,16 +429,16 @@
 	  "<a href='https://www.lionfederal.com/privacy-policy.html' style='color: inherit; text-decoration: underline;'>Privacy Policy</a>";
 </script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="assets/vendors/jquery/jquery.min.js"><\/script>')</script>
-<script src="assets/vendors/bootstrap/js/bootstrap.min.js"></script>
-<script src="assets/vendors/OwlCarousel/owl.carousel.min.js"></script>
+<script>window.jQuery || document.write('<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"><\/script>')</script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js"></script>
 <!-- <script src="assets/vendors/owl-carousel/owl.carousel.min.js"></script>-->
-<script src="assets/vendors/wow/wow.min.js"></script>
-<script src="assets/vendors/responsivetabs/responsivetabs.js"></script>
-<script src="assets/vendors/fancybox/jquery.fancybox.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/wow/1.1.2/wow.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/js/easyResponsiveTabs.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-<script src="assets/js/ie10-viewport-bug-workaround.js"></script>
-<script src="assets/js/customjs.js"></script>
+<script src="ie10-viewport-bug-workaround.js"></script>
+<script src="customjs.js"></script>
 
 <script>
 		// Function to hide all sections

--- a/about-us.html
+++ b/about-us.html
@@ -15,27 +15,27 @@
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,700i,800,800i" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Raleway:400,700,900" rel="stylesheet">
     <!-- Bootstrap core CSS -->
-    <link href="assets/vendors/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
 	<!--<link href="assets/vendors/owl-carousel/owl.carousel.css" rel="stylesheet">-->
-	<link href="assets/vendors/fancybox/jquery.fancybox.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" rel="stylesheet">
 	
 	<!--fontawesome core css-->
-	<link href="assets/vendors/fontawesome/css/font-awesome.min.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 	
 	<!-- Animate CSS -->
-	<link href="assets/vendors/animate/animate.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.2/animate.min.css" rel="stylesheet">
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-    <link href="assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
+    <link href="ie10-viewport-bug-workaround.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="assets/css/style.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
 	
 	 <!-- Owl Carousel -->
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.carousel.min.css">
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.theme.default.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.theme.default.min.css">
 	
-	 <link href="assets/vendors/responsivetabs/responsivetabs.css" rel="stylesheet">
+	 <link href="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/easy-responsive-tabs.min.css" rel="stylesheet">
 	 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-685Z66HVS9"></script>
 <script>
@@ -337,16 +337,16 @@
 	  "<a href='https://www.lionfederal.com/privacy-policy.html' style='color: inherit; text-decoration: underline;'>Privacy Policy</a>";
 </script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="assets/vendors/jquery/jquery.min.js"><\/script>')</script>
-<script src="assets/vendors/bootstrap/js/bootstrap.min.js"></script>
-<script src="assets/vendors/OwlCarousel/owl.carousel.min.js"></script>
+<script>window.jQuery || document.write('<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"><\/script>')</script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js"></script>
 <!-- <script src="assets/vendors/owl-carousel/owl.carousel.min.js"></script>-->
-<script src="assets/vendors/wow/wow.min.js"></script>
-<script src="assets/vendors/responsivetabs/responsivetabs.js"></script>
-<script src="assets/vendors/fancybox/jquery.fancybox.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/wow/1.1.2/wow.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/js/easyResponsiveTabs.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-<script src="assets/js/ie10-viewport-bug-workaround.js"></script>
-<script src="assets/js/customjs.js"></script>
+<script src="ie10-viewport-bug-workaround.js"></script>
+<script src="customjs.js"></script>
 
 <script>
 	new WOW().init();

--- a/careers.html
+++ b/careers.html
@@ -15,27 +15,27 @@
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,700i,800,800i" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Raleway:400,700,900" rel="stylesheet">
     <!-- Bootstrap core CSS -->
-    <link href="assets/vendors/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
 	<!--<link href="assets/vendors/owl-carousel/owl.carousel.css" rel="stylesheet">-->
-	<link href="assets/vendors/fancybox/jquery.fancybox.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" rel="stylesheet">
 	
 	<!--fontawesome core css-->
-	<link href="assets/vendors/fontawesome/css/font-awesome.min.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 	
 	<!-- Animate CSS -->
-	<link href="assets/vendors/animate/animate.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.2/animate.min.css" rel="stylesheet">
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-    <link href="assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
+    <link href="ie10-viewport-bug-workaround.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="assets/css/style.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
 	
 	 <!-- Owl Carousel -->
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.carousel.min.css">
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.theme.default.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.theme.default.min.css">
 	
-	 <link href="assets/vendors/responsivetabs/responsivetabs.css" rel="stylesheet">
+	 <link href="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/easy-responsive-tabs.min.css" rel="stylesheet">
 
 	 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-685Z66HVS9"></script>
@@ -238,16 +238,16 @@
 	  "<a href='https://www.lionfederal.com/privacy-policy.html' style='color: inherit; text-decoration: underline;'>Privacy Policy</a>";
 </script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="assets/vendors/jquery/jquery.min.js"><\/script>')</script>
-<script src="assets/vendors/bootstrap/js/bootstrap.min.js"></script>
-<script src="assets/vendors/OwlCarousel/owl.carousel.min.js"></script>
+<script>window.jQuery || document.write('<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"><\/script>')</script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js"></script>
 <!-- <script src="assets/vendors/owl-carousel/owl.carousel.min.js"></script>-->
-<script src="assets/vendors/wow/wow.min.js"></script>
-<script src="assets/vendors/responsivetabs/responsivetabs.js"></script>
-<script src="assets/vendors/fancybox/jquery.fancybox.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/wow/1.1.2/wow.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/js/easyResponsiveTabs.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-<script src="assets/js/ie10-viewport-bug-workaround.js"></script>
-<script src="assets/js/customjs.js"></script>
+<script src="ie10-viewport-bug-workaround.js"></script>
+<script src="customjs.js"></script>
 
 <script>
 	new WOW().init();

--- a/digicloud.html
+++ b/digicloud.html
@@ -15,27 +15,27 @@
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,700i,800,800i" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Raleway:400,700,900" rel="stylesheet">
     <!-- Bootstrap core CSS -->
-    <link href="assets/vendors/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
 	<!--<link href="assets/vendors/owl-carousel/owl.carousel.css" rel="stylesheet">-->
-	<link href="assets/vendors/fancybox/jquery.fancybox.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" rel="stylesheet">
 	
 	<!--fontawesome core css-->
-	<link href="assets/vendors/fontawesome/css/font-awesome.min.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 	
 	<!-- Animate CSS -->
-	<link href="assets/vendors/animate/animate.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.2/animate.min.css" rel="stylesheet">
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-    <link href="assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
+    <link href="ie10-viewport-bug-workaround.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="assets/css/style.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
 	
 	 <!-- Owl Carousel -->
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.carousel.min.css">
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.theme.default.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.theme.default.min.css">
 	
-	 <link href="assets/vendors/responsivetabs/responsivetabs.css" rel="stylesheet">
+	 <link href="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/easy-responsive-tabs.min.css" rel="stylesheet">
 	 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-685Z66HVS9"></script>
 <script>
@@ -297,16 +297,16 @@ DigiCloud’s versatile Professional Engineers provide customized facility quali
 	  "<a href='https://www.lionfederal.com/privacy-policy.html' style='color: inherit; text-decoration: underline;'>Privacy Policy</a>";
 </script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="assets/vendors/jquery/jquery.min.js"><\/script>')</script>
-<script src="assets/vendors/bootstrap/js/bootstrap.min.js"></script>
-<script src="assets/vendors/OwlCarousel/owl.carousel.min.js"></script>
+<script>window.jQuery || document.write('<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"><\/script>')</script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js"></script>
 <!-- <script src="assets/vendors/owl-carousel/owl.carousel.min.js"></script>-->
-<script src="assets/vendors/wow/wow.min.js"></script>
-<script src="assets/vendors/responsivetabs/responsivetabs.js"></script>
-<script src="assets/vendors/fancybox/jquery.fancybox.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/wow/1.1.2/wow.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/js/easyResponsiveTabs.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-<script src="assets/js/ie10-viewport-bug-workaround.js"></script>
-<script src="assets/js/customjs.js"></script>
+<script src="ie10-viewport-bug-workaround.js"></script>
+<script src="customjs.js"></script>
 
 <script>
 	new WOW().init();

--- a/index.html
+++ b/index.html
@@ -15,27 +15,27 @@
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,700i,800,800i" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Raleway:400,700,900" rel="stylesheet">
     <!-- Bootstrap core CSS -->
-    <link href="assets/vendors/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
 	<!--<link href="assets/vendors/owl-carousel/owl.carousel.css" rel="stylesheet">-->
-	<link href="assets/vendors/fancybox/jquery.fancybox.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" rel="stylesheet">
 	
 	<!--fontawesome core css-->
-	<link href="assets/vendors/fontawesome/css/font-awesome.min.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 	
 	<!-- Animate CSS -->
-	<link href="assets/vendors/animate/animate.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.2/animate.min.css" rel="stylesheet">
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-    <link href="assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
+    <link href="ie10-viewport-bug-workaround.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="assets/css/style.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
 	
 	 <!-- Owl Carousel -->
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.carousel.min.css">
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.theme.default.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.theme.default.min.css">
 	
-	 <link href="assets/vendors/responsivetabs/responsivetabs.css" rel="stylesheet">
+	 <link href="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/easy-responsive-tabs.min.css" rel="stylesheet">
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-685Z66HVS9"></script>
 <script>
@@ -302,16 +302,16 @@
 </script>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="assets/vendors/jquery/jquery.min.js"><\/script>')</script>
-<script src="assets/vendors/bootstrap/js/bootstrap.min.js"></script>
-<script src="assets/vendors/OwlCarousel/owl.carousel.min.js"></script>
+<script>window.jQuery || document.write('<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"><\/script>')</script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js"></script>
 <!-- <script src="assets/vendors/owl-carousel/owl.carousel.min.js"></script>-->
-<script src="assets/vendors/wow/wow.min.js"></script>
-<script src="assets/vendors/responsivetabs/responsivetabs.js"></script>
-<script src="assets/vendors/fancybox/jquery.fancybox.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/wow/1.1.2/wow.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/js/easyResponsiveTabs.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-<script src="assets/js/ie10-viewport-bug-workaround.js"></script>
-<script src="assets/js/customjs.js"></script>
+<script src="ie10-viewport-bug-workaround.js"></script>
+<script src="customjs.js"></script>
 
 <script>
 	new WOW().init();

--- a/news.html
+++ b/news.html
@@ -16,27 +16,27 @@
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,700i,800,800i" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Raleway:400,700,900" rel="stylesheet">
 	<!-- Bootstrap core CSS -->
-	<link href="assets/vendors/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+	<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
 	<!--<link href="assets/vendors/owl-carousel/owl.carousel.css" rel="stylesheet">-->
-	<link href="assets/vendors/fancybox/jquery.fancybox.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" rel="stylesheet">
 
 	<!--fontawesome core css-->
-	<link href="assets/vendors/fontawesome/css/font-awesome.min.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 
 	<!-- Animate CSS -->
-	<link href="assets/vendors/animate/animate.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.2/animate.min.css" rel="stylesheet">
 
 	<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-	<link href="assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
+	<link href="ie10-viewport-bug-workaround.css" rel="stylesheet">
 
 	<!-- Custom styles for this template -->
-	<link href="assets/css/style.css" rel="stylesheet">
+	<link href="style.css" rel="stylesheet">
 
 	<!-- Owl Carousel -->
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.carousel.min.css">
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.theme.default.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.theme.default.min.css">
 
-	<link href="assets/vendors/responsivetabs/responsivetabs.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/easy-responsive-tabs.min.css" rel="stylesheet">
 	<!-- Global site tag (gtag.js) - Google Analytics -->
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-685Z66HVS9"></script>
 	<script>
@@ -2019,16 +2019,16 @@
 		  "<a href='https://www.lionfederal.com/privacy-policy.html' style='color: inherit; text-decoration: underline;'>Privacy Policy</a>";
 	</script>
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-	<script>window.jQuery || document.write('<script src="assets/vendors/jquery/jquery.min.js"><\/script>')</script>
-	<script src="assets/vendors/bootstrap/js/bootstrap.min.js"></script>
-	<script src="assets/vendors/OwlCarousel/owl.carousel.min.js"></script>
+	<script>window.jQuery || document.write('<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"><\/script>')</script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js"></script>
 	<!-- <script src="assets/vendors/owl-carousel/owl.carousel.min.js"></script>-->
-	<script src="assets/vendors/wow/wow.min.js"></script>
-	<script src="assets/vendors/responsivetabs/responsivetabs.js"></script>
-	<script src="assets/vendors/fancybox/jquery.fancybox.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/wow/1.1.2/wow.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/js/easyResponsiveTabs.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 	<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-	<script src="assets/js/ie10-viewport-bug-workaround.js"></script>
-	<script src="assets/js/customjs.js"></script>
+	<script src="ie10-viewport-bug-workaround.js"></script>
+	<script src="customjs.js"></script>
 
 	<script>
 		new WOW().init();

--- a/sectors.html
+++ b/sectors.html
@@ -15,27 +15,27 @@
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,700i,800,800i" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Raleway:400,700,900" rel="stylesheet">
     <!-- Bootstrap core CSS -->
-    <link href="assets/vendors/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
 	<!--<link href="assets/vendors/owl-carousel/owl.carousel.css" rel="stylesheet">-->
-	<link href="assets/vendors/fancybox/jquery.fancybox.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" rel="stylesheet">
 	
 	<!--fontawesome core css-->
-	<link href="assets/vendors/fontawesome/css/font-awesome.min.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 	
 	<!-- Animate CSS -->
-	<link href="assets/vendors/animate/animate.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.2/animate.min.css" rel="stylesheet">
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-    <link href="assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
+    <link href="ie10-viewport-bug-workaround.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="assets/css/style.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
 	
 	 <!-- Owl Carousel -->
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.carousel.min.css">
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.theme.default.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.theme.default.min.css">
 	
-	 <link href="assets/vendors/responsivetabs/responsivetabs.css" rel="stylesheet">
+	 <link href="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/easy-responsive-tabs.min.css" rel="stylesheet">
 
 	 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-685Z66HVS9"></script>
@@ -238,16 +238,16 @@
 	  "<a href='https://www.lionfederal.com/privacy-policy.html' style='color: inherit; text-decoration: underline;'>Privacy Policy</a>";
 </script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="assets/vendors/jquery/jquery.min.js"><\/script>')</script>
-<script src="assets/vendors/bootstrap/js/bootstrap.min.js"></script>
-<script src="assets/vendors/OwlCarousel/owl.carousel.min.js"></script>
+<script>window.jQuery || document.write('<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"><\/script>')</script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js"></script>
 <!-- <script src="assets/vendors/owl-carousel/owl.carousel.min.js"></script>-->
-<script src="assets/vendors/wow/wow.min.js"></script>
-<script src="assets/vendors/responsivetabs/responsivetabs.js"></script>
-<script src="assets/vendors/fancybox/jquery.fancybox.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/wow/1.1.2/wow.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/js/easyResponsiveTabs.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-<script src="assets/js/ie10-viewport-bug-workaround.js"></script>
-<script src="assets/js/customjs.js"></script>
+<script src="ie10-viewport-bug-workaround.js"></script>
+<script src="customjs.js"></script>
 
 <script>
 	new WOW().init();

--- a/services.html
+++ b/services.html
@@ -15,27 +15,27 @@
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,700i,800,800i" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Raleway:400,700,900" rel="stylesheet">
     <!-- Bootstrap core CSS -->
-    <link href="assets/vendors/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
 	<!--<link href="assets/vendors/owl-carousel/owl.carousel.css" rel="stylesheet">-->
-	<link href="assets/vendors/fancybox/jquery.fancybox.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" rel="stylesheet">
 	
 	<!--fontawesome core css-->
-	<link href="assets/vendors/fontawesome/css/font-awesome.min.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 	
 	<!-- Animate CSS -->
-	<link href="assets/vendors/animate/animate.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.2/animate.min.css" rel="stylesheet">
 
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-    <link href="assets/css/ie10-viewport-bug-workaround.css" rel="stylesheet">
+    <link href="ie10-viewport-bug-workaround.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="assets/css/style.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
 	
 	 <!-- Owl Carousel -->
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.carousel.min.css">
-	<link rel="stylesheet" href="assets/vendors/OwlCarousel/owl.theme.default.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.theme.default.min.css">
 	
-	 <link href="assets/vendors/responsivetabs/responsivetabs.css" rel="stylesheet">
+	 <link href="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/easy-responsive-tabs.min.css" rel="stylesheet">
 	 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-685Z66HVS9"></script>
 <script>
@@ -405,16 +405,16 @@
 	  "<a href='https://www.lionfederal.com/privacy-policy.html' style='color: inherit; text-decoration: underline;'>Privacy Policy</a>";
 </script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="assets/vendors/jquery/jquery.min.js"><\/script>')</script>
-<script src="assets/vendors/bootstrap/js/bootstrap.min.js"></script>
-<script src="assets/vendors/OwlCarousel/owl.carousel.min.js"></script>
+<script>window.jQuery || document.write('<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"><\/script>')</script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js"></script>
 <!-- <script src="assets/vendors/owl-carousel/owl.carousel.min.js"></script>-->
-<script src="assets/vendors/wow/wow.min.js"></script>
-<script src="assets/vendors/responsivetabs/responsivetabs.js"></script>
-<script src="assets/vendors/fancybox/jquery.fancybox.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/wow/1.1.2/wow.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/easy-responsive-tabs/2.2.0/js/easyResponsiveTabs.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-<script src="assets/js/ie10-viewport-bug-workaround.js"></script>
-<script src="assets/js/customjs.js"></script>
+<script src="ie10-viewport-bug-workaround.js"></script>
+<script src="customjs.js"></script>
 
 <script>
 	new WOW().init();

--- a/style.css
+++ b/style.css
@@ -56,7 +56,7 @@ h1, h2, h3, h4, h5, h6{
 }
 
 .about-banner, .services-banner, .sectors-banner, .news-banner, .careers-banner  {
-	background-image: url(../../assets/images/about-banner.jpg);
+	background-image: url(assets/about-banner.jpg);
     top: 0px;
     right: 0;
     left: 0;
@@ -68,7 +68,7 @@ h1, h2, h3, h4, h5, h6{
 }
 
 .about-sc-4  {
-	background-image: url(../../assets/images/contact-bg.jpg);
+	background-image: url(assets/contact-bg.jpg);
 	background-repeat: no-repeat;
 	background-size: cover;
 	position: relative;
@@ -76,7 +76,7 @@ h1, h2, h3, h4, h5, h6{
 }
 
 .darkblue-gradient {
-	background-image: url(../../assets/images/gradient-bg.jpg);
+	background-image: url(assets/gradient-bg.jpg);
 	color: #fff;
 	background-attachment: fixed;
 	background-repeat: no-repeat;
@@ -92,7 +92,7 @@ h1, h2, h3, h4, h5, h6{
 }
 
 .banner-sc {
-	background-image: url(../../assets/images/banner-main.jpg);
+	background-image: url(assets/banner-main.jpg);
     height: 100vh;
 	background-repeat: no-repeat;
 	background-size: cover;
@@ -110,7 +110,7 @@ h1, h2, h3, h4, h5, h6{
 }
 
 .sc-3 {
-	background-image: url(../../assets/images/services-bg.jpg);
+	background-image: url(assets/services-bg.jpg);
 	background-repeat: no-repeat;
 	background-size: cover;
 	position: relative;
@@ -827,18 +827,18 @@ span.bottom-spacer {
 }
 
 .services-list-data1 {
-	background-image: url(../../assets/images/services-icon1-bg.jpg);
+	background-image: url(assets/services-icon1-bg.jpg);
 }
 
 .services-list-data2 {
-	background-image: url(../../assets/images/services-icon2-bg.jpg);
+	background-image: url(assets/services-icon2-bg.jpg);
 }
 
 .services-list-data3 {
-	background-image: url(../../assets/images/services-icon3-bg.jpg);
+	background-image: url(assets/services-icon3-bg.jpg);
 }
 .services-list-data4 {
-	background-image: url(../../assets/images/database_background.jpg);
+	background-image: url(assets/database_background.jpg);
 }
 
 
@@ -1317,12 +1317,12 @@ ul.checklist li:before {
 
 @font-face {
 	font-family: 'OpenSans Extrabold';
-	src: url('../fonts/OpenSans-Extrabold.eot'); 
-	src: url('../fonts/OpenSans-Extrabold.eot?#iefix') format('embedded-opentype'), 
-	url('../fonts/OpenSans-Extrabold.woff2') format('woff2'), 
-	url('../fonts/OpenSans-Extrabold.woff') format('woff'), 
-	url('../fonts/OpenSans-Extrabold.ttf')  format('truetype'), 
-	url('../fonts/OpenSans-Extrabold.svg#svgFontName') format('svg'); 
+	src: url('assets/OpenSans-Extrabold.eot'); 
+	src: url('assets/OpenSans-Extrabold.eot?#iefix') format('embedded-opentype'), 
+	url('assets/OpenSans-Extrabold.woff2') format('woff2'), 
+	url('assets/OpenSans-Extrabold.woff') format('woff'), 
+	url('assets/OpenSans-Extrabold.ttf')  format('truetype'), 
+	url('assets/OpenSans-Extrabold.svg#svgFontName') format('svg'); 
 	font-weight: normal;
 	font-style: normal;
 }
@@ -1331,24 +1331,24 @@ ul.checklist li:before {
 
 @font-face {
 	font-family: 'OpenSans Regular';
-	src: url('../fonts/OpenSans.eot'); 
-	src: url('../fonts/OpenSans.eot?#iefix') format('embedded-opentype'), 
-	url('../fonts/OpenSans.woff2') format('woff2'), 
-	url('../fonts/OpenSans.woff') format('woff'), 
-	url('../fonts/OpenSans.ttf')  format('truetype'), 
-	url('../fonts/OpenSans.svg#svgFontName') format('svg'); 
+	src: url('assets/OpenSans.eot'); 
+	src: url('assets/OpenSans.eot?#iefix') format('embedded-opentype'), 
+	url('assets/OpenSans.woff2') format('woff2'), 
+	url('assets/OpenSans.woff') format('woff'), 
+	url('assets/OpenSans.ttf')  format('truetype'), 
+	url('assets/OpenSans.svg#svgFontName') format('svg'); 
 	font-weight: normal;
 	font-style: normal;
 }
 
 @font-face {
 	font-family: 'Raleway Bold';
-	src: url('../fonts/Raleway-Bold.eot'); 
-	src: url('../fonts/Raleway-Bold.eot?#iefix') format('embedded-opentype'), 
-	url('../fonts/Raleway-Bold.woff2') format('woff2'), 
-	url('../fonts/Raleway-Bold.woff') format('woff'), 
-	url('../fonts/Raleway-Bold.ttf')  format('truetype'), 
-	url('../fonts/Raleway-Bold.svg#svgFontName') format('svg'); 
+	src: url('assets/Raleway-Bold.eot'); 
+	src: url('assets/Raleway-Bold.eot?#iefix') format('embedded-opentype'), 
+	url('assets/Raleway-Bold.woff2') format('woff2'), 
+	url('assets/Raleway-Bold.woff') format('woff'), 
+	url('assets/Raleway-Bold.ttf')  format('truetype'), 
+	url('assets/Raleway-Bold.svg#svgFontName') format('svg'); 
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
## Summary
- fix broken CSS/JS paths
- use CDN versions of vendor libraries
- update style.css asset references
- add `.nojekyll` so GitHub Pages serves raw files

## Testing
- `tidy -e index.html`

------
https://chatgpt.com/codex/tasks/task_b_688141ef5050832db79110a3b36da8b8